### PR TITLE
feat: implement dropdown context management with single dropdown state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/Components/DropDown/DropDown.jsx
+++ b/src/Components/DropDown/DropDown.jsx
@@ -1,19 +1,40 @@
-import React, { useState } from 'react';
-
+import React, {  useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-
 import classes from './DropDown.module.css';
+import { useDropdown } from '../../Hooks/useDropdown';
 
 const DropDown = (props) => {
-    const [open, setOpen] = useState(false);
+    const { openDropdownId, toggleDropdown } = useDropdown();
+    const menuRef = useRef(null);
+    const dropdownId = props.id || 'default-dropdown';
+    const isOpen = openDropdownId === dropdownId;
+  
+    useEffect(() => {
+      const handleClickOutside = (event) => {
+        if (menuRef.current && !menuRef.current.contains(event.target)) {
+          toggleDropdown(dropdownId);
+        }
+      }
+  
+      if (isOpen) {
+        document.addEventListener('click', handleClickOutside);
+      } else {
+        document.removeEventListener('click', handleClickOutside);
+      }
+  
+      return () => {
+        document.removeEventListener('click', handleClickOutside);
+      };
+    }, [isOpen, toggleDropdown, dropdownId]);
 
-    const handleOpen = () => {
-        setOpen(!open);
+    const handleOpen = (event) => {
+        event.stopPropagation();
+        toggleDropdown(dropdownId);
     };
 
     const handleSelect = (key) => {
         props.setSelected(key);
-        setOpen(false);
+        toggleDropdown(dropdownId);
     };
 
     return (
@@ -32,7 +53,7 @@ const DropDown = (props) => {
                         />
 
                         <path
-                            className={`${classes.toggleArrow} ${open ? classes.toggled : ''}`}
+                            className={`${classes.toggleArrow} ${isOpen ? classes.toggled : ''}`}
                             fillRule="evenodd"
                             clipRule="evenodd"
                             d="M9.20711 11.3894C8.76165 11.3894 8.53857 11.928 8.85355 12.243L11.6464 15.0359C11.8417 15.2311 12.1583 15.2311 12.3536 15.0358L15.1464 12.243C15.4614 11.928 15.2383 11.3894 14.7929 11.3894H9.20711Z"
@@ -41,10 +62,10 @@ const DropDown = (props) => {
                     </svg>
                 </div>
             </button>
-            {open ? (
-                <ul className={classes.menu}>
+            {isOpen ? (
+                <ul className={classes.menu} ref={menuRef}>
                     {props.options.map(({ option, key, icon }) => (
-                        <li className={classes['menu-item']}>
+                        <li key={key} className={classes['menu-item'] }>
                             <button className={classes.button} onClick={() => handleSelect(key)}>
                                 {icon}
                                 {option}
@@ -58,6 +79,7 @@ const DropDown = (props) => {
 };
 
 DropDown.propTypes = {
+    id: PropTypes.string,
     selected: PropTypes.string,
     setSelected: PropTypes.func,
     label: PropTypes.string,

--- a/src/Hooks/useDropdown.jsx
+++ b/src/Hooks/useDropdown.jsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { DropdownContext } from '../Providers/DropdownProvider';
+
+export const useDropdown = () => {
+  const context = useContext(DropdownContext);
+  if (!context) {
+    throw new Error('useDropdown must be used within DropdownProvider');
+  }
+  return context;
+};

--- a/src/Pages/Rates/Rates.jsx
+++ b/src/Pages/Rates/Rates.jsx
@@ -10,7 +10,7 @@ import classes from './Rates.module.css';
 
 import CountryData from '../../Libs/Countries.json';
 import countryToCurrency from '../../Libs/CountryCurrency.json';
-
+import { DropdownProvider } from '../../Providers/DropdownProvider';
 let countries = CountryData.CountryCodes;
 
 const Rates = () => {
@@ -47,6 +47,7 @@ const Rates = () => {
     });
 
     return (
+        <DropdownProvider>
         <div className={classes.container}>
             <div className={classes.content}>
                 <div className={classes.heading}>Currency Conversion</div>
@@ -54,6 +55,7 @@ const Rates = () => {
                 <div className={classes.rowWrapper}>
                     <div>
                         <DropDown
+                            id="from-currency"
                             leftIcon={<Flag code={fromCurrency} />}
                             label={'From'}
                             selected={countryToCurrency[fromCurrency]}
@@ -79,6 +81,7 @@ const Rates = () => {
 
                     <div>
                         <DropDown
+                            id="to-currency"
                             leftIcon={<Flag code={toCurrency} />}
                             label={'To'}
                             selected={countryToCurrency[toCurrency]}
@@ -108,6 +111,7 @@ const Rates = () => {
                 )}
             </div>
         </div>
+        </DropdownProvider>
     );
 };
 

--- a/src/Providers/DropdownProvider.jsx
+++ b/src/Providers/DropdownProvider.jsx
@@ -1,0 +1,37 @@
+import { useState, useCallback, createContext } from 'react';
+
+export const DropdownContext = createContext({
+    openDropdownId: null,
+    openDropdown: () => {},
+    closeDropdown: () => {},
+    toggleDropdown: () => {}
+});
+
+export const DropdownProvider = ({ children }) => {
+  const [openDropdownId, setOpenDropdownId] = useState(null);
+
+  const openDropdown = useCallback((id) => {
+    setOpenDropdownId(id);
+  }, []);
+
+  const closeDropdown = useCallback(() => {
+    setOpenDropdownId(null);
+  }, []);
+
+  const toggleDropdown = useCallback((id) => {
+    setOpenDropdownId(prev => prev === id ? null : id);
+  }, []);
+
+  const contextValue = {
+    openDropdownId,
+    openDropdown,
+    closeDropdown,
+    toggleDropdown
+  };
+
+  return (
+    <DropdownContext.Provider value={contextValue}>
+      {children}
+    </DropdownContext.Provider>
+  );
+};


### PR DESCRIPTION
- Add DropdownProvider with Context API for centralized dropdown state management
- Create useDropdown hook for easy access to dropdown context
- Refactor DropDown component to use context instead of local state
- Add unique IDs to dropdowns in Rates page for proper state tracking
- Implement single dropdown open state (only one dropdown can be open at a time)
- Fix linter errors by removing undefined variables and unused imports
- Optimize performance by using string state instead of array for dropdown IDs