### PR TITLE
feat: freeze conversion display; fix input loops; keep values while loading

### DIFF
--- a/src/Components/ConversionResult/ConversionResult.jsx
+++ b/src/Components/ConversionResult/ConversionResult.jsx
@@ -1,13 +1,28 @@
 import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
 import Loader from '../Loader/Loader';
 import ValueDisplay from '../ValueDisplay';
 import classes from './ConversionResult.module.css';
 
 const ConversionResult = (props) => {
-    
     // Use external loading state or internal state
     const isLoading = props.isLoading !== undefined ? props.isLoading : false;
-    
+
+    // Preserve last known values while loading
+    const [displayTrueAmount, setDisplayTrueAmount] = useState(props.trueAmount);
+    const [displayAmountAfterMarkup, setDisplayAmountAfterMarkup] = useState(props.amountAfterMarkup);
+    const [displayCurrency, setDisplayCurrency] = useState(props.currency);
+    const [displayLeftIcon, setDisplayLeftIcon] = useState(props.leftIcon);
+
+    useEffect(() => {
+        if (!isLoading) {
+            setDisplayTrueAmount(props.trueAmount);
+            setDisplayAmountAfterMarkup(props.amountAfterMarkup);
+            setDisplayCurrency(props.currency);
+            setDisplayLeftIcon(props.leftIcon);
+        }
+    }, [props.trueAmount, props.amountAfterMarkup, props.currency, props.leftIcon, isLoading]);
+
     return (
         <div className={classes.conversionResultContainer}>
             <div className={classes.conversionResultHeader}>
@@ -16,8 +31,8 @@ const ConversionResult = (props) => {
             </div>
             <div className={classes.conversionResultContent}>
                 {isLoading ? <div className={classes.loadingCover}><Loader width={'25px'} height={'25px'} /></div> : null}
-                <ValueDisplay title={'True Amount'} isLoading={isLoading} leftIcon={props.leftIcon} amount={props.trueAmount} currency={props.currency}/>
-                <ValueDisplay title={'Amount After Markup'} isLoading={isLoading} leftIcon={props.leftIcon} amount={props.amountAfterMarkup} currency={props.currency}/>
+                <ValueDisplay title={'True Amount'} isLoading={isLoading} leftIcon={displayLeftIcon} amount={displayTrueAmount} currency={displayCurrency}/>
+                <ValueDisplay title={'Amount After Markup'} isLoading={isLoading} leftIcon={displayLeftIcon} amount={displayAmountAfterMarkup} currency={displayCurrency}/>
             </div>
         </div>
     )

--- a/src/Components/Input/Input.jsx
+++ b/src/Components/Input/Input.jsx
@@ -1,172 +1,174 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';      
-import classes from './Input.module.css';
+import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import classes from './Input.module.css';
 import { useDebounce } from '../../Hooks/useDebounce';
 
 const Input = (props) => {
-    const [isError, setIsError] = useState(false);
-    // Validation states: pending/valid/invalid for each rule
-    const [validationStates, setValidationStates] = useState({
+  const [isError, setIsError] = useState(false);
+  const [validationStates, setValidationStates] = useState({
+    onlyNumbers: 'pending',
+    noLeadingDot: 'pending',
+    singleDecimal: 'pending',
+    maxIntegerDigits: 'pending',
+    maxDecimalDigits: 'pending',
+  });
+  const inputRef = useRef(null);
+
+  // Debounced value + debouncing flag
+  const { debouncedValue, isDebouncing } = useDebounce(props.value);
+
+  // Check if current input is valid
+  const isValid = props.value === '' || 
+    (validationStates.onlyNumbers !== 'invalid' && 
+    validationStates.noLeadingDot !== 'invalid' && 
+    validationStates.singleDecimal !== 'invalid' && 
+    validationStates.maxIntegerDigits !== 'invalid' && 
+    validationStates.maxDecimalDigits !== 'invalid');
+
+  // Validate current input value
+  const validateAmount = (value) => {
+    if (value === '') {
+      setValidationStates({
         onlyNumbers: 'pending',
         noLeadingDot: 'pending',
         singleDecimal: 'pending',
         maxIntegerDigits: 'pending',
-        maxDecimalDigits: 'pending'
-    });
-    const inputRef = useRef(null);
+        maxDecimalDigits: 'pending',
+      });
+      setIsError(false);
+      return;
+    }
 
-    // Debounce input value with loading state
-    const { debouncedValue, isDebouncing } = useDebounce(props.value);
-
-    // Validate amount input with real-time feedback
-    const validateAmount = (value) => {
-        if (value === '') {
-            setValidationStates({
-                onlyNumbers: 'pending',
-                noLeadingDot: 'pending',
-                singleDecimal: 'pending',
-                maxIntegerDigits: 'pending',
-                maxDecimalDigits: 'pending'
-            });
-            setIsError(false);
-            return;
-        }
-
-        // Check if input contains only numbers and decimal points
-        const onlyNumbersValid = /^[\d.]+$/.test(value);
-        
-        const states = {
-            onlyNumbers: onlyNumbersValid ? 'valid' : 'invalid',
-            noLeadingDot: !value.startsWith('.') ? 'valid' : 'invalid',
-            singleDecimal: (value.match(/\./g) || []).length <= 1 ? 'valid' : 'invalid',
-            maxIntegerDigits: 'valid',
-            maxDecimalDigits: 'valid'
-        };
-
-        // If non-numeric chars exist, digit validation fails too
-        if (!onlyNumbersValid) {
-            states.maxIntegerDigits = 'invalid';
-            states.maxDecimalDigits = 'invalid';
-        } else {
-            // Validate digit limits only for numeric input
-            const parts = value.split('.');
-            const integerPart = parts[0];
-            if (integerPart.length > 9) {
-                states.maxIntegerDigits = 'invalid';
-            }
-
-            const decimalPart = parts[1] || '';
-            if (decimalPart.length > 2) {
-                states.maxDecimalDigits = 'invalid';
-            }
-        }
-
-        setValidationStates(states);
-        setIsError(Object.values(states).some(state => state === 'invalid'));
+    const onlyNumbersValid = /^[\d.]+$/.test(value);
+    const next = {
+      onlyNumbers: onlyNumbersValid ? 'valid' : 'invalid',
+      noLeadingDot: !value.startsWith('.') ? 'valid' : 'invalid',
+      singleDecimal: (value.match(/\./g) || []).length <= 1 ? 'valid' : 'invalid',
+      maxIntegerDigits: 'valid',
+      maxDecimalDigits: 'valid',
     };
 
-    useEffect(() => {
-        validateAmount(props.value);
-    }, [props.value]);
+    if (!onlyNumbersValid) {
+      next.maxIntegerDigits = 'invalid';
+      next.maxDecimalDigits = 'invalid';
+    } else {
+      const [integerPart, decimalPart = ''] = value.split('.');
+      if (integerPart.length > 9) next.maxIntegerDigits = 'invalid';
+      if (decimalPart.length > 2) next.maxDecimalDigits = 'invalid';
+    }
 
-    // Check if current value is valid for debouncing
-    const isCurrentValueValid = useCallback(() => {
-        if (props.value === '') return true;
-        return !Object.values(validationStates).some(state => state === 'invalid');
-    }, [props.value, validationStates]);
-      
+    setValidationStates(next);
+    // Check if any validation rule failed
+    const hasErrors = next.onlyNumbers === 'invalid' || 
+      next.noLeadingDot === 'invalid' || 
+      next.singleDecimal === 'invalid' || 
+      next.maxIntegerDigits === 'invalid' || 
+      next.maxDecimalDigits === 'invalid';
+    setIsError(hasErrors);
+  };
 
-    // Notify parent about debouncing state and debounced value
-    useEffect(() => {
-        if (props.onDebouncingChange) {
-            // Keep loading if current value is invalid
-            const shouldKeepLoading = isDebouncing || !isCurrentValueValid();
-            props.onDebouncingChange(shouldKeepLoading);
-        }
-        if (props.onDebouncedValueChange) {
-            // Only update debounced value if current value is valid
-            if (isCurrentValueValid()) {
-                props.onDebouncedValueChange(debouncedValue);
-            }
-            // Don't update debounced value if current value is invalid
-            // This prevents showing '0' when transitioning from invalid to valid
-        }
-    }, [isDebouncing, debouncedValue, isCurrentValueValid, props.onDebouncingChange, props.onDebouncedValueChange, props]);
+  useEffect(() => {
+    validateAmount(props.value);
+  }, [props.value]);
 
-    const handleContainerClick = () => {
-        inputRef.current?.focus(); 
-    };
+  // Notify parent only when values truly change (prevents render-effect loops)
+  const prevDebouncingRef = useRef();
+  const prevDebouncedRef = useRef();
 
-    // Get CSS class based on validation state
-    const getIndicatorStyle = (state) => {
-        return state === 'pending' ? classes.pending : 
-               state === 'valid' ? classes.valid : classes.invalid;
-    };
+  useEffect(() => {
+    const nextDebouncing = isDebouncing || !isValid;
 
-    // Get symbol based on validation state: ∙ for pending, ✓ for valid, ✗ for invalid
-    const getIndicatorSymbol = (state) => {
-        return state === 'pending' ? '∙ ' : 
-               state === 'valid' ? '✓ ' : '✗ ';
-    };
+    if (
+      props.onDebouncingChange &&
+      nextDebouncing !== prevDebouncingRef.current
+    ) {
+      prevDebouncingRef.current = nextDebouncing;
+      props.onDebouncingChange(nextDebouncing);
+    }
 
-    return (
-        <div className={`${classes.container} ${props.className}`} style={props.style} onClick={handleContainerClick}>
-            {props.label && (
-                <span className={`${classes.label} ${isError ? classes.errorLabel : ''}`}>
-                    {isError ? 'Please enter a valid amount' : props.label}
-                </span>
-            )}
-            <div className={`${classes.inputWrapper} ${isError ? classes.errorInputWrapper : ''}`}>
-                {props.leftIcon}
-                <input 
-                    type='text' 
-                    ref={inputRef} 
-                    className={classes.input} 
-                    placeholder="00.00" 
-                    value={props.value} 
-                    onChange={props.onChange}
-                    maxLength={12} // 9 digits + 1 dot + 2 decimals
-                />
-                <span className={classes.currency}>{props.currency}</span>
-            </div>
-            
-            {/* validation indicators */}
-            <div className={classes.validationIndicators}>
-                <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.onlyNumbers)}`}>
-                    <span className={classes.symbol}>{getIndicatorSymbol(validationStates.onlyNumbers)}</span>
-                    Only numbers and decimal point
-                </div>
-                <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.noLeadingDot)}`}>
-                    <span className={classes.symbol}>{getIndicatorSymbol(validationStates.noLeadingDot)}</span>
-                    No leading decimal point
-                </div>
-                <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.singleDecimal)}`}>
-                    <span className={classes.symbol}>{getIndicatorSymbol(validationStates.singleDecimal)}</span>
-                    Single decimal point
-                </div>
-                <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.maxIntegerDigits)}`}>
-                    <span className={classes.symbol}>{getIndicatorSymbol(validationStates.maxIntegerDigits)}</span>
-                    Max 9 integer digits
-                </div>
-                <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.maxDecimalDigits)}`}>
-                    <span className={classes.symbol}>{getIndicatorSymbol(validationStates.maxDecimalDigits)}</span>
-                    Max 2 decimal digits
-                </div>
-            </div>
+    if (
+      props.onDebouncedValueChange &&
+      isValid &&
+      debouncedValue !== prevDebouncedRef.current
+    ) {
+      prevDebouncedRef.current = debouncedValue;
+      props.onDebouncedValueChange(debouncedValue);
+    }
+  }, [isDebouncing, debouncedValue, isValid, props.onDebouncingChange, props.onDebouncedValueChange]);
+
+  const handleContainerClick = () => {
+    inputRef.current?.focus();
+  };
+
+  const getIndicatorStyle = (state) =>
+    state === 'pending' ? classes.pending : state === 'valid' ? classes.valid : classes.invalid;
+
+  const getIndicatorSymbol = (state) =>
+    state === 'pending' ? '∙ ' : state === 'valid' ? '✓ ' : '✗ ';
+
+  return (
+    <div
+      className={`${classes.container} ${props.className}`}
+      style={props.style}
+      onClick={handleContainerClick}
+    >
+      {props.label && (
+        <span className={`${classes.label} ${isError ? classes.errorLabel : ''}`}>
+          {isError ? 'Please enter a valid amount' : props.label}
+        </span>
+      )}
+
+      <div className={`${classes.inputWrapper} ${isError ? classes.errorInputWrapper : ''}`}>
+        {props.leftIcon}
+        <input
+          type="text"
+          ref={inputRef}
+          className={classes.input}
+          placeholder="00.00"
+          value={props.value}
+          onChange={props.onChange}
+          maxLength={12}
+        />
+        <span className={classes.currency}>{props.currency}</span>
+      </div>
+
+      {/* compact validation indicators */}
+      <div className={classes.validationIndicators}>
+        <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.onlyNumbers)}`}>
+          <span className={classes.symbol}>{getIndicatorSymbol(validationStates.onlyNumbers)}</span>
+          Only numbers and decimal point
         </div>
-    )
-}
+        <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.noLeadingDot)}`}>
+          <span className={classes.symbol}>{getIndicatorSymbol(validationStates.noLeadingDot)}</span>
+          No leading decimal point
+        </div>
+        <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.singleDecimal)}`}>
+          <span className={classes.symbol}>{getIndicatorSymbol(validationStates.singleDecimal)}</span>
+          Single decimal point
+        </div>
+        <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.maxIntegerDigits)}`}>
+          <span className={classes.symbol}>{getIndicatorSymbol(validationStates.maxIntegerDigits)}</span>
+          Max 9 integer digits
+        </div>
+        <div className={`${classes.indicator} ${getIndicatorStyle(validationStates.maxDecimalDigits)}`}>
+          <span className={classes.symbol}>{getIndicatorSymbol(validationStates.maxDecimalDigits)}</span>
+          Max 2 decimal digits
+        </div>
+      </div>
+    </div>
+  );
+};
 
 Input.propTypes = {
-    className: PropTypes.string,
-    value: PropTypes.string,
-    onChange: PropTypes.func,
-    onDebouncingChange: PropTypes.func,
-    onDebouncedValueChange: PropTypes.func,
-    style: PropTypes.object,
-    label: PropTypes.string,
-    currency: PropTypes.string,
-    leftIcon: PropTypes.element,
-}
+  className: PropTypes.string,
+  style: PropTypes.object,
+  label: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onDebouncingChange: PropTypes.func,
+  onDebouncedValueChange: PropTypes.func,
+  currency: PropTypes.string,
+  leftIcon: PropTypes.element,
+};
 
 export default Input;

--- a/src/Hooks/useExchangeRate.jsx
+++ b/src/Hooks/useExchangeRate.jsx
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from 'react';
+
+export const useExchangeRate = (sellCurrency, buyCurrency, setLoading) => {
+    const [exchangeRate, setExchangeRate] = useState(1);
+    const [error, setError] = useState(null);
+
+    const fetchRate = useCallback(async () => {
+        if (!sellCurrency || !buyCurrency) return;
+        
+        setLoading(true);
+        setError(null);
+        
+        try {
+            const response = await fetch(`https://rates.staging.api.paytron.com/rate/public?sellCurrency=${sellCurrency}&buyCurrency=${buyCurrency}`);
+            
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            
+            const data = await response.json();
+            
+            if (data.retailRate !== undefined) {
+                setExchangeRate(data.retailRate);
+            } else {
+                throw new Error('Invalid response format');
+            }
+        } catch (err) {
+            console.error('Error fetching exchange rate:', err);
+            setError(err.message);
+            // Keep previous exchange rate on error
+        } finally {
+            setLoading(false);
+        }
+    }, [sellCurrency, buyCurrency]);
+
+    useEffect(() => {
+        fetchRate();
+    }, [fetchRate]);
+
+    return { 
+        exchangeRate, 
+        error, 
+        refetch: fetchRate
+    };
+};

--- a/src/Pages/Rates/Rates.module.css
+++ b/src/Pages/Rates/Rates.module.css
@@ -22,17 +22,25 @@
 .rowWrapper {
     display: flex;
     flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
 }
 .exchangeWrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: flex-end;
-    margin: 0px 30px;
+}
+
+.rateDescription {
+    font-size: 13px;
+    color: #142557;
+    opacity: 0.7;
 }
 
 .transferIcon {
-    margin-bottom: 18px;
+    margin-top: 2px;
+    margin-bottom: 5px;
 }
 .transferIcon > svg > path {
     fill: #142557;
@@ -41,6 +49,8 @@
     font-size: 18px;
     color: #142557;
     opacity: 0.7;
+    font-weight: 600;
+
 }
 
 .flag {
@@ -54,6 +64,7 @@
     display: flex;
     justify-content: center;
     margin-top: 20px;
+
 }
 .slow {
     transition: all 1s cubic-bezier(0.55, 0.055, 0.675, 0.19) !important;

--- a/src/Utils/currencyConvertUtil.js
+++ b/src/Utils/currencyConvertUtil.js
@@ -1,17 +1,17 @@
 import Decimal from 'decimal.js';
 
-// Convert amount with rate, handle empty/invalid input
-export const convertAmount = (amount, rate) => {
+// Convert amount with true rate (without markup), handle empty/invalid input
+export const convertAmount = (amount, rate, markup) => {
     if (!amount || amount === '' || isNaN(amount)) {
         return '0';
     }
-    return new Decimal(amount).mul(rate).toString();
+    return new Decimal(amount).mul(rate).div(1 - markup).toFixed(2).toString();
 }
 
-// Convert amount with rate and markup, handle empty/invalid input
-export const convertAmountWithMarkup = (amount, rate, markup) => {
+// Convert amount with OFX true rate, handle empty/invalid input
+export const convertAmountWithMarkup = (amount, rate) => {
     if (!amount || amount === '' || isNaN(amount)) {
         return '0';
     }
-    return new Decimal(amount).mul(rate).mul(1 - markup).toString();
+    return new Decimal(amount).mul(rate).toFixed(2).toString();
 }


### PR DESCRIPTION
- Rates: freeze on debouncing/loading/error and on currency change; reset progress; show rate loader
- Input: notify parent only on actual value changes; simplify validation and error checks
- ConversionResult: cache amounts/currency/icon; update only when not loading